### PR TITLE
Combine data processing with web server

### DIFF
--- a/Itog2.js
+++ b/Itog2.js
@@ -442,4 +442,16 @@ async function main() {
   console.log('Создан combined_output.xlsx');
 }
 
-main().catch(err => console.error('Ошибка выполнения:', err));
+async function run() {
+  try {
+    await main();
+  } catch (err) {
+    console.error('Ошибка выполнения:', err);
+  }
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { main };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ssr",
+  "version": "1.0.0",
+  "description": "",
+  "main": "Itog2.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "exceljs": "^4.4.0",
+    "express": "^5.1.0",
+    "xlsx": "^0.18.5",
+    "xml2js": "^0.6.2"
+  }
+}


### PR DESCRIPTION
## Summary
- export `main` function from `Itog2.js` and run only when executed directly
- update `app_s.js` to load Excel data on request and call `Itog2.main` via `/generate`
- add a button on the web page to trigger generation
- style the new button
- add minimal `package.json` for dependencies

## Testing
- `node --check app_s.js`
- `node --check Itog2.js`
- `node app_s.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6841720123f4832980b947b6a8a21ce3