### PR TITLE
Extend web interface with upload and editing

### DIFF
--- a/Itog2.js
+++ b/Itog2.js
@@ -442,4 +442,16 @@ async function main() {
   console.log('Создан combined_output.xlsx');
 }
 
-main().catch(err => console.error('Ошибка выполнения:', err));
+async function run() {
+  try {
+    await main();
+  } catch (err) {
+    console.error('Ошибка выполнения:', err);
+  }
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { main };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ssr",
+  "version": "1.0.0",
+  "description": "",
+  "main": "Itog2.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "exceljs": "^4.4.0",
+    "express": "^5.1.0",
+    "express-fileupload": "^1.4.0",
+    "xlsx": "^0.18.5",
+    "xml2js": "^0.6.2"
+  }
+}


### PR DESCRIPTION
## Summary
- allow uploading new `.gge` files via `/upload`
- add `/edit` interface for modifying group and TEP data
- expose `/combined` endpoint to download the Excel file
- include new navigation buttons on the main page
- add `express-fileupload` dependency

## Testing
- `node --check app_s.js`
- `node --check Itog2.js`
- `npm install`
- `node app_s.js` *(server started)*


------
https://chatgpt.com/codex/tasks/task_e_6841720123f4832980b947b6a8a21ce3